### PR TITLE
Core: wrap sdclang commands with ccache

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -502,10 +502,10 @@ my_target_global_ldflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_LD
         my_target_global_cppflags += $(SDCLANG_COMMON_FLAGS) $(SDCLANG_PRECONFIGURED_FLAGS)
 
         ifeq ($(strip $(my_cc)),)
-            my_cc := $(SDCLANG_PATH)/clang
+            my_cc := $(my_cc_wrapper) $(SDCLANG_PATH)/clang
         endif
         ifeq ($(strip $(my_cxx)),)
-            my_cxx := $(SDCLANG_PATH)/clang++
+            my_cxx := $(my_cxx_wrapper) $(SDCLANG_PATH)/clang++
         endif
     endif
 else


### PR DESCRIPTION
As far as I am aware (and through testing of my own), sdclang commands are not getting wrapped for ccache.

Reason for this is in the private variable assignment section, when my_cc is stripped, it is not empty, so a wrapper is never assigned. Since it is not going to be touched until the PRIVATE_CC or PRIVATE_CXX variable assignment, we can just do it here.

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>